### PR TITLE
Add JSON validation tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: python -m pip install --upgrade pip
+      - run: python -m unittest discover -v

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # profile
 公開用の設定ファイル。
+
+## テストの実行
+
+Python 3 がインストールされている環境で次のコマンドを実行します。
+
+```bash
+python3 -m unittest discover -v
+```
+
+`test_profile.py` が `profile.json` の JSON 構造を検証します。

--- a/test_profile.py
+++ b/test_profile.py
@@ -1,0 +1,32 @@
+import json
+import os
+import unittest
+from datetime import datetime
+
+class TestProfileJSON(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = os.path.join(os.path.dirname(__file__), 'profile.json')
+        with open(path, 'r', encoding='utf-8') as f:
+            cls.data = json.load(f)
+
+    def test_required_fields(self):
+        required_fields = [
+            'name', 'language', 'description', 'contacts',
+            'created_at', 'updated_at'
+        ]
+        for field in required_fields:
+            self.assertIn(field, self.data)
+
+    def test_contacts_is_list(self):
+        self.assertIsInstance(self.data.get('contacts'), list)
+
+    def test_timestamp_format(self):
+        for key in ['created_at', 'updated_at']:
+            value = self.data.get(key)
+            self.assertIsInstance(value, str)
+            # basic ISO8601 check
+            datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `test_profile.py` for validating `profile.json`
- run the tests in CI via GitHub Actions
- document how to run tests locally

## Testing
- `python3 -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_6840882f47808321b3c49e7d6f8c8d04